### PR TITLE
Added comment in ad5940.c

### DIFF
--- a/ad5940.c
+++ b/ad5940.c
@@ -4130,7 +4130,6 @@ DACCALERROR_TIMEOUT:
  * @return AD5940ERR_OK if succeed.
  *AD5940_LPDACCal() function is added here only to suggest an optional LPDAC calibration sequence.
  *It is not verified by ADI software team and user may use it at own risk.
-
 **/
 AD5940Err AD5940_LPDACCal(LPDACCal_Type *pCalCfg, LPDACPara_Type *pResult)
 {

--- a/ad5940.c
+++ b/ad5940.c
@@ -4124,10 +4124,13 @@ DACCALERROR_TIMEOUT:
 
 /**
  * @brief Use ADC to measure LPDAC offset and gain factor.
- * @note Assume ADC is accurate enough or accurate than LPDAC at least.
+ * @note Assuming ADC is accurate enough or accurate than LPDAC at least.
  * @param pCalCfg: pointer to structure.
  * @param pResult: the pointer to save calibration result.
  * @return AD5940ERR_OK if succeed.
+ *AD5940_LPDACCal() function is added here only to suggest an optional LPDAC calibration sequence.
+ *It is not verified by ADI software team and user may use it at own risk.
+
 **/
 AD5940Err AD5940_LPDACCal(LPDACCal_Type *pCalCfg, LPDACPara_Type *pResult)
 {


### PR DESCRIPTION
Added comment " LPDACCal() function is added in ad5940.c only to suggest an optional LPDAC calibration sequence.
It is not verified by ADI software team and user may use it at own risk.”
in ad5940.c